### PR TITLE
No need to define development default url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,6 @@ title: dtc innovation
 tag_text: dtc innovation
 description: >
   We design, prototype and engineer innovation for the web and for the commons.
-url: "http://127.0.0.1:4000"
 baseurl: ""
 
 font-awesome-include: false


### PR DESCRIPTION
Default development URL is automatically set for JEKYLL_ENV=development since Jekyll 3.3

See : https://jamstatic.fr/2016/10/07/jekyll-3-3-est-dispo/

Also url is optional and should be correctly set by GitHub Pages during the build.