### PR TITLE
Ignore default Jekyll destination, sass-cache and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Jekyll
+_site/
+.sass-cache/
+.jekyll-metadata


### PR DESCRIPTION
This is standard default values to ignore for Jekyll