### PR TITLE
Assemblées générales 2017/2018/2019

### DIFF
--- a/collections/_decisions/2016-09-16.md
+++ b/collections/_decisions/2016-09-16.md
@@ -1,6 +1,10 @@
 ---
 title: Assemblée générale constitutive du 16 septembre 2016
 date: 2016-09-26
+signees:
+- David
+- Thomas
+- Clémentine
 ---
 
 # Procès-verbal de l’assemblée générale constitutive du 16 septembre 2016

--- a/collections/_decisions/2017-02-10.md
+++ b/collections/_decisions/2017-02-10.md
@@ -1,9 +1,13 @@
 ---
-title: Assemblée Générale Exceptionnelle 10 février 2017
+title: Assemblée Générale Exceptionnelle du 10 février 2017
 date: 2017-02-10
+signees:
+- David
+- Thomas
+- Clémentine
 ---
 
-# Compte-rendu de l’Assemblée Générale Exceptionnelle 10 février 2017
+# Compte-rendu de l’Assemblée Générale Exceptionnelle du 10 février 2017
 
 Personnes présentes :
 
@@ -11,7 +15,7 @@ Personnes présentes :
 - Clémentine Hahn
 - Thomas Parisot
 
-Réunis le 10 février 2017 en assemblée générale exceptionnelle, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants : 
+Réunis le 10 février 2017 en assemblée générale exceptionnelle, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants :
 
 ## Rémunération
 
@@ -19,11 +23,11 @@ Réunis le 10 février 2017 en assemblée générale exceptionnelle, les présen
 
 ## Recrutement
 
-Compte-tenu des prévisions de trésorerie de l’association pour l’année 2017, les Membres Noyaux de l’association dtc innovation décident des actions suivantes : 
+Compte-tenu des prévisions de trésorerie de l’association pour l’année 2017, les Membres Noyaux de l’association dtc innovation décident des actions suivantes :
 
 - Il est proposé à **David Bruant** un **CDI** à partir du **1er mars 2017** initialement à temps plein avec une rémunération de **1480,27 euros bruts mensuel** (SMIC) ;
 - Il est proposé à **Clémentine Hahn** un **CDI** à partir du **1er avril 2017** initialement à temps plein avec une rémunération de **1870,00 euros bruts mensuel** ;
-- Il est proposé à **Thomas Parisot** un **CDI** à partir du **1er juillet 2017** initialement à temps plein. Les conditions exactes (tâches, rémunération) restent à déterminer. 
+- Il est proposé à **Thomas Parisot** un **CDI** à partir du **1er juillet 2017** initialement à temps plein. Les conditions exactes (tâches, rémunération) restent à déterminer.
 
 Un salarié ne pouvant pas signer son propre contrat, les Membres Noyaux se relaieront pour signer le contrat les uns des autres :
 
@@ -38,8 +42,8 @@ Une lettre de promesse d’embauche à été envoyée à **Renaud Forestié** le
 ## Complémentaire santé
 
 - Pour mutuelle d’entreprise obligatoire, dtc innovation choisit Pavillon Prévoyance ;
-- Pour les salariés ne pouvant pas bénéficier de la complémentaire santé mise en place (par exemple parce que résidant à l’étranger), dtc innovation prend en charge le paiement ou remboursement de la complémentaire santé à 100% à hauteur de 70€ maximum par mois et par personne. Toute personne ayant une mutuelle à un tarif supérieur à 70€/mois assumera personnellement le reste à charge financier. 
+- Pour les salariés ne pouvant pas bénéficier de la complémentaire santé mise en place (par exemple parce que résidant à l’étranger), dtc innovation prend en charge le paiement ou remboursement de la complémentaire santé à 100% à hauteur de 70€ maximum par mois et par personne. Toute personne ayant une mutuelle à un tarif supérieur à 70€/mois assumera personnellement le reste à charge financier.
 
 ---
 
-> À Bordeaux, le 10 février 2017 
+> À Bordeaux, le 10 février 2017

--- a/collections/_decisions/2017-06-28.md
+++ b/collections/_decisions/2017-06-28.md
@@ -1,9 +1,13 @@
 ---
-title: Assemblée Générale Exceptionnelle 28 Juin 2017
+title: Assemblée Générale Exceptionnelle du 28 Juin 2017
 date: 2017-06-28
+signees:
+- David
+- Thomas
+- Clémentine
 ---
 
-# Compte-rendu de l’Assemblée Générale Exceptionnelle 28 Juin 2017
+# Compte-rendu de l’Assemblée Générale Exceptionnelle du 28 Juin 2017
 
 Personnes présentes :
 
@@ -12,47 +16,37 @@ Personnes présentes :
 - Thomas Parisot
 
 
-Réunis le 28 juin 2017 en assemblée générale exceptionnelle, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants : 
+Réunis le 28 juin 2017 en assemblée générale exceptionnelle, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants :
 
 
 # Recrutement
 
-Compte-tenu des prévisions de trésorerie de l’association pour l’année 2017, les Membres Noyaux de l’association dtc innovation décident des actions suivantes : 
+Compte-tenu des prévisions de trésorerie de l’association pour l’année 2017, les Membres Noyaux de l’association dtc innovation décident des actions suivantes :
 
-- Il est proposé à **Thomas Parisot** un **CDI** à partir du **1er juillet 2017** initialement à **temps plein** avec une rémunération de 2384,00 euros bruts mensuel. 
+- Il est proposé à **Thomas Parisot** un **CDI** à partir du **1er juillet 2017** initialement à **temps plein** avec une rémunération de 2384,00 euros bruts mensuel.
 
 Un salarié ne pouvant pas signer son propre contrat, David Bruant représentera dtc innovation pour signer le contrat de Thomas Parisot.
 
 # Rémunération
 
 - Tout rémunération, initiale et/ou modifiée, des salarié·e·s de l’association dtc innovation est soumise à la décision des autres salariés lors d’Assemblées Générales extraordinaires ;
-- La limite haute d’une rémunération d’un·e salarié·e est définie par sa capacité à être potentiellement étendue aux autres salarié·e·s sous réserve que la trésorerie de l’association le permette. 
+- La limite haute d’une rémunération d’un·e salarié·e est définie par sa capacité à être potentiellement étendue aux autres salarié·e·s sous réserve que la trésorerie de l’association le permette.
 
 # Modifications de rémunération
 
-- À partir du 1er septembre 2017 la rémunération nette mensuelle des membres noyaux salariés David Bruant et Clémentine Hahn sera de 1800 € net mensuel. 
+- À partir du 1er septembre 2017 la rémunération nette mensuelle des membres noyaux salariés David Bruant et Clémentine Hahn sera de 1800 € net mensuel.
 
 # Complémentaire santé
 
-Lors de l’[AG du 10 février 2017](2017-02-10.md), il a été décidé que dtc innovation prend en charge le paiement ou remboursement de la complémentaire santé à 100% à hauteur de 70€ maximum par mois et par personne pour les salariés ne pouvant ou ne voulant pas bénéficier de la complémentaire santé mise en place parce que résidant à l’étranger. 
+Lors de l’[AG du 10 février 2017](2017-02-10.md), il a été décidé que dtc innovation prend en charge le paiement ou remboursement de la complémentaire santé à 100% à hauteur de 70€ maximum par mois et par personne pour les salariés ne pouvant ou ne voulant pas bénéficier de la complémentaire santé mise en place parce que résidant à l’étranger.
 
 - En conséquence dtc innovation décide de prendre en charge l’assurance santé de Clémentine Hahn à partir du 25 août 2017 et ce pour les deux années de sa résidence au Canada, soit jusqu’au 24 août 2019 ;
 - Étant donné que :
 	- La santé et l’indépendance financière des conjoints de fait des salariés de dtc innovation a un impact majeure sur la disponibilité et la capacité de travail desdits salariés ;
-	- L’assurance coûte 29,7€ par mois et par personne. Par conséquent, le montant cumulé de l’assurance de Clémentine Hahn et de son conjoint de fait Jonathan Labbé est de 59,4€ par mois soit 1425,6€ au total pour les 24 mois. 
+	- L’assurance coûte 29,7€ par mois et par personne. Par conséquent, le montant cumulé de l’assurance de Clémentine Hahn et de son conjoint de fait Jonathan Labbé est de 59,4€ par mois soit 1425,6€ au total pour les 24 mois.
 - Il a été décidé que dtc innovation prenne en charge l’assurance santé de Jonathan Labbé pour les de deux années de sa résidence au Canada à partir du 25 août 2017, soit jusqu’au 24 août 2019 ;
 - Le paiement des assurances santé de Clémentine Hahn et de son conjoint Jonathan Labbé sera fait par dtc innovation en une seule fois, avant leur entrée au Canada conformément aux directives de l’immigration canadienne et pour une durée de 24 mois, soit la durée initiale de leur visa de résidence au Canada.
 
 ---
 
 > À Saint-Victor-de-Buthon, le 28 juin 2017.
-
-
-
-
-
-
-
-
-
-

--- a/collections/_decisions/2017-10-06.md
+++ b/collections/_decisions/2017-10-06.md
@@ -1,0 +1,32 @@
+---
+title: Assemblée Générale Ordinaire du 6 octobre 2017
+date: 2017-10-06
+signees:
+- David
+- Thomas
+- Clémentine
+---
+
+# Compte-rendu de l’Assemblée Générale Ordinaire du 6 octobre 2017
+
+Personnes présentes :
+
+-   David Bruant
+-   Clémentine Hahn
+-   Thomas Parisot
+
+
+Réunis le 6 octobre 2017 en assemblée générale ordinaire, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants :
+
+
+# Élection d'une nouvelle personne au poste de président·e
+
+Les membres noyaux de l’association votent la nouvelle présidence de l’association. A l’unanimité, Clémentine Hahn est désignée nouvelle présidente de l’association dtc innovation.
+
+# Santé des salarié·e·s
+
+Il est décidé que l’association remboursera les frais d'optiques des membres noyaux qui resteraient à charge après traitement du dossier par leur complémentaires santé.
+
+---
+
+> A Paris, le 6 octobre 2017.

--- a/collections/_decisions/2018-05-27.md
+++ b/collections/_decisions/2018-05-27.md
@@ -1,0 +1,28 @@
+---
+title: Assemblée Générale Exceptionnelle du 27 mai 2018
+date: 2018-05-27
+signees:
+- David
+- Thomas
+- Clémentine
+---
+
+# Compte-rendu de l’Assemblée Générale Exceptionnelle du 27 mai 2018
+
+Personnes présentes :
+
+-   David Bruant
+-   Clémentine Hahn
+-   Thomas Parisot
+
+
+Réunis le 27 mai 2018 en assemblée générale exceptionnelle, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants :
+
+
+# Rémunération
+
+Etant donné les difficultées de trésorerie ponctuelles rencontrées et pour préserver les ressources de l’association il est décidé que la rémunération des trois salariés serait modifiée pour se conformer au minimum légal à partir du mois de juin 2018 et ce jusqu’à ce qu’une nouvelle Assemblée Générale Extraordinaire vienne modifier la présente décision.
+
+---
+
+> A Anduze, le 27 mai 2018.

--- a/collections/_decisions/2018-08-01.md
+++ b/collections/_decisions/2018-08-01.md
@@ -1,0 +1,29 @@
+---
+title: Assemblée Générale Exceptionnelle du 1er août 2018
+date: 2018-08-01
+signees:
+- David
+- Thomas
+- Clémentine
+---
+
+# Compte-rendu de l’Assemblée Générale Exceptionnelle du 1er août 2018
+
+Personnes présentes :
+
+-   David Bruant
+-   Clémentine Hahn
+-   Thomas Parisot
+
+
+Réunis le 1er août 2018 en assemblée générale exceptionnelle, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants :
+
+
+# Affectation du résultat
+
+L'exercice comptable 2017, exercé entre le 1er janvier et le 31 décembre 2017, aboutit à un résultat positif de 94273,00€.<br>
+Ce résultat est affecté intégralement à une réserve libre.
+
+---
+
+> A Bordeaux, le 1er août 2018.

--- a/collections/_decisions/2018-09-04.md
+++ b/collections/_decisions/2018-09-04.md
@@ -1,0 +1,33 @@
+---
+title: Assemblée Générale Exceptionnelle du 4 septembre 2018
+date: 2018-09-04
+signees:
+- David
+- Thomas
+- Clémentine
+---
+
+# Compte-rendu de l’Assemblée Générale Exceptionnelle du 4 septembre 2018
+
+Personnes présentes :
+
+-   David Bruant
+-   Clémentine Hahn
+-   Thomas Parisot
+
+
+Réunis le 04 septembre 2018 en assemblée générale exceptionnelle, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants :
+
+
+# Licenciement économique
+
+Les membres noyaux de l’association votent le licenciement économique de Clémentine Hahn. À l’unanimité, les membres décident des actions suivantes :
+
+- Il est décidé d'un commun accord que le contrat s'achève le 5 octobre 2018 ;
+- Il est proposé une indemnité de départ de 5000,00€ ;
+- La notification de licenciement sera envoyée le 5 septembre 2018 ;
+- Le solde de tout compte apparaîtra sur le bulletin de paie d'octobre 2018.
+
+---
+
+> A Montréal, le 4 septembre 2018.

--- a/collections/_decisions/2018-10-05.md
+++ b/collections/_decisions/2018-10-05.md
@@ -1,0 +1,28 @@
+---
+title: Assemblée Générale Ordinaire du 5 octobre 2018
+date: 2018-10-05
+signees:
+- David
+- Thomas
+- Clémentine
+---
+
+# Compte-rendu de l’Assemblée Générale Ordinaire du 5 octobre 2018
+
+Personnes présentes :
+
+-   David Bruant
+-   Clémentine Hahn
+-   Thomas Parisot
+
+
+Réunis le 5 octobre 2018 en assemblée générale, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants :
+
+
+# Élection d'une nouvelle personne au poste de président·e
+
+Les membres noyaux de l’association votent la nouvelle présidence de l’association. À l’unanimité, Clémentine Hahn est élue présidente de l’association dtc innovation.
+
+---
+
+> A Bordeaux, le 5 octobre 2018.

--- a/collections/_decisions/2019-04-30.md
+++ b/collections/_decisions/2019-04-30.md
@@ -1,0 +1,28 @@
+---
+title: Assemblée Générale Exceptionnelle du 30 avril 2019
+date: 2019-04-30
+signees:
+- David
+- Thomas
+- Clémentine
+---
+
+# Compte-rendu de l’Assemblée Générale Exceptionnelle du 30 avril 2019
+
+Personnes présentes :
+
+-   David Bruant
+-   Clémentine Hahn
+-   Thomas Parisot
+
+
+Réunis le 30 avril 2019 en assemblée générale exceptionnelle, les présents nommés Membres Noyaux de l’association dtc innovation ont décidé à l’unanimité des principes suivants :
+
+
+# Affectation du résultat
+
+L'exercice comptable 2018, exercé entre le 1er janvier et le 31 décembre 2018, aboutit à un résultat déficitaire de -27332,00€.
+
+---
+
+> A Bordeaux, le 30 avril 2019.

--- a/valeurs.html
+++ b/valeurs.html
@@ -1,5 +1,5 @@
 ---
-title: Values, policies and company documentation.
+title: Valeurs et vie associative.
 layout: page
 menu_order: 4
 menu_title: Valeurs
@@ -46,7 +46,7 @@ permalink: /dna/
 
   <ol>
   {% for decision in site.decisions  %}
-  <li><a href="{{ decision.url }}">{{ decision.title }}</a></li>
+  <li><a href="{{ decision.url }}" rel="permalink">{{ decision.title }}</a></li>
   {% endfor %}
   </ol>
 


### PR DESCRIPTION
C'est la copie conforme aux Google Docs.

À l'exception de l'AG du [4 septembre 2018](https://docs.google.com/document/d/1YnpBcTOgdgVfuMo3hNsBu_KJ4DNgTi4p3gZ-99WvvhA/edit), sous forme de proposition.